### PR TITLE
Temporarily disable capsule on disk until HP Dev One supports it

### DIFF
--- a/plugins/uefi-capsule/uefi_capsule.conf
+++ b/plugins/uefi-capsule/uefi_capsule.conf
@@ -19,4 +19,4 @@
 #FallbacktoRemovablePath=false
 
 # allow ignoring the CapsuleOnDisk support advertised by the firmware
-#DisableCapsuleUpdateOnDisk=true
+DisableCapsuleUpdateOnDisk=true


### PR DESCRIPTION
This fixes firmware updates from LVFS with the latest fwupd.
