### PR TITLE
Rebase on Debian's 1.8.2-1 packaging

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+fwupd (1.8.2-1pop1) jammy; urgency=medium
+
+  * Pop!_OS backport
+
+ -- Ian Scott <idscott@system76.com>  Thu, 14 Jul 2022 15:56:56 -0700
+
 fwupd (1.8.2-1) unstable; urgency=medium
 
   [ Mario Limonciello ]

--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (quilt)
+3.0 (native)


### PR DESCRIPTION
Updates fwupd to the latest release and cherry-picks the commit from https://github.com/fwupd/fwupd/pull/4767. We'll want to test that this addresses any issues flashing Launch, as well as general regression testing.